### PR TITLE
Fix installation instructions for luarocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Using LuaRocks (http://luarocks.org):
 
 * Install current Git master head from GitHub:
 
-    sudo luarocks install lua-cmsgpack --from=rocks-cvs
+    sudo luarocks install lua-cmsgpack scm-1 --server=https://luarocks.org/dev
 
 * Install from current working copy
 


### PR DESCRIPTION
With the flag "--from=rocks-cvs", luarocks fails to find the latest and greatest and falls back to version 0.4.0-0. This version is vulnerable to CVE-2018-11218.